### PR TITLE
Register task routes in Express server

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,16 @@
 import express from "express";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { registerRoutes } from "./routes.js";
 
 const app = express();
 
 app.use(express.json());
 
-// Exempel-API
+// Register API routes
+registerRoutes(app);
+
+// Health check endpoint
 app.get("/api/health", (_req, res) => res.json({ ok: true }));
 
 // Serva byggd frontend

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,10 +1,9 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
-import { storage } from "./storage";
+import { storage } from "./storage.js";
 import { insertTaskSchema } from "@shared/schema";
 import { z } from "zod";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export function registerRoutes(app: Express): void {
   // Task routes
   app.get("/api/tasks", async (req, res) => {
     try {
@@ -82,8 +81,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ error: "Failed to clear tasks" });
     }
   });
-
-  const httpServer = createServer(app);
-
-  return httpServer;
 }


### PR DESCRIPTION
## Summary
- register the REST task routes with the Express application during server startup
- simplify the route module so it only attaches handlers without instantiating a separate HTTP server

## Testing
- npm run dev:server *(fails: ts-node-dev binary is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71cf679c8321a0c1718e4716e330