### PR TITLE
Fix server build path resolution for shared schema

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import type { Express } from "express";
 import { storage } from "./storage.js";
-import { insertTaskSchema } from "@shared/schema";
+import { insertTaskSchema } from "../shared/schema.js";
 import { z } from "zod";
 
 export function registerRoutes(app: Express): void {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { type Task, type InsertTask, calculateCategory } from "@shared/schema";
+import { type Task, type InsertTask, calculateCategory } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 
 export interface IStorage {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./",
+    "rootDir": "../",
     "outDir": "./dist",
     "module": "Node16",
     "target": "ES2022",
@@ -12,5 +12,6 @@
     "noEmit": false,
     "allowImportingTsExtensions": false
   },
-  "include": ["./index.ts"]
+  "include": ["./index.ts", "./routes.ts", "./storage.ts", "../shared/**/*.ts"],
+  "exclude": ["./vite.ts", "../client", "../node_modules", "./dist"]
 }


### PR DESCRIPTION
## Summary
- update server imports to reference the shared schema with relative paths so Node16 module resolution can resolve them
- adjust the server TypeScript config to include the shared sources in the build output and exclude dev-only files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca76eec2d88321b86a923919027471