### PR TITLE
Fix static asset resolution for production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:client": "vite build",
     "build:server": "cd server && tsc -p tsconfig.json",
     "build": "npm run build:client && npm run build:server",
-    "start": "node server/dist/index.js"
+    "start": "node server/dist/server/index.js"
   },
   "engines": {
     "node": ">=18"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { registerRoutes } from "./routes.js";
@@ -17,11 +18,27 @@ app.get("/api/health", (_req, res) => res.json({ ok: true }));
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const clientDist = path.join(__dirname, "../../dist/public");
-app.use(express.static(clientDist));
-app.get("*", (_req, res) =>
-  res.sendFile(path.join(clientDist, "index.html"))
+const clientDistCandidates = [
+  // When running the TypeScript sources directly (ts-node-dev)
+  path.resolve(__dirname, "..", "dist", "public"),
+  // When running the compiled server output (server/dist/server/index.js)
+  path.resolve(__dirname, "..", "..", "..", "dist", "public"),
+];
+
+const clientDist = clientDistCandidates.find((candidate) =>
+  existsSync(candidate)
 );
+
+if (clientDist) {
+  app.use(express.static(clientDist));
+  app.get("*", (_req, res) =>
+    res.sendFile(path.join(clientDist, "index.html"))
+  );
+} else {
+  console.warn(
+    "⚠️ Client build output not found. Static assets will not be served."
+  );
+}
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- resolve the client build directory dynamically so both ts-node and compiled builds serve assets correctly
- adjust the start script to execute the compiled server entry point

## Testing
- npm run build
- npm start (terminated manually)


------
https://chatgpt.com/codex/tasks/task_e_68ca7bb7a5a483218e5135f4600e4ab3