### PR TITLE
Configure Vite dev proxy for API requests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,5 +33,11 @@ export default defineConfig({
       strict: true,
       deny: ["**/.*"],
     },
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- configure the Vite dev server to proxy /api requests to the Express backend running on port 3000

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68ca7f56ee5c8321ba7d47c967eb4089