### PR TITLE
Align category calculation with slider thresholds

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,8 +22,8 @@ export type Task = typeof tasks.$inferSelect;
 
 // Category calculation helper
 export function calculateCategory(timeRating: number, valueRating: number): string {
-  const isQuick = timeRating >= 6; // 6-10 = quick (higher score = quicker)
-  const isHighValue = valueRating >= 6; // 6-10 = high value
+  const isQuick = timeRating >= 8; // 8-10 = quick (higher score = quicker)
+  const isHighValue = valueRating >= 8; // 8-10 = high value
   
   if (isQuick && isHighValue) return 'A';
   if (!isQuick && isHighValue) return 'B';


### PR DESCRIPTION
## Summary
- align the quick and high-value thresholds with the slider labels by requiring ratings of at least eight for category A

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caaada96b48321af91a3ffc328d64f